### PR TITLE
Fix 'adam' learning rate method

### DIFF
--- a/cs231n/optim.py
+++ b/cs231n/optim.py
@@ -133,10 +133,15 @@ def adam(x, dx, config=None):
     # TODO: Implement the Adam update formula, storing the next value of x in #
     # the next_x variable. Don't forget to update the m, v, and t variables   #
     # stored in config.                                                       #
-    ###########################################################################
+    ###########################################################################  
+    
+    config['t'] += 1
     config['m'] = config['beta1'] * config['m'] + (1 - config['beta1']) * dx
     config['v'] = config['beta2'] * config['v'] + (1 - config['beta2']) * (dx ** 2)
-    next_x = x - config['learning_rate'] * config['m'] / (np.sqrt(config['v'] + config['epsilon']))
+    mt = config['m'] / (1 - config['beta1']**config['t'])
+    vt = config['v'] / (1 - config['beta2']**config['t'])
+    next_x = x - config['learning_rate'] * mt / (np.sqrt(vt) + config['epsilon'])
+
     ###########################################################################
     #                             END OF YOUR CODE                            #
     ###########################################################################


### PR DESCRIPTION
Start using an iteration number (`config['t']`)
Before:
```
next_w error:  0.20720703807110674
v error:  4.208314038113071e-09
m error:  4.214963193114416e-09
```
After:
```
next_w error:  1.1395691798535431e-07
v error:  4.208314038113071e-09
m error:  4.214963193114416e-09
```
